### PR TITLE
Add audit dashboard and process specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-- 👋 Hi, I’m @Chrystale75
-- 👀 I’m interested in learning code and no-code...
-- 🌱 I’m currently learning no code
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# Cahier des charges – Audit et Conformité
 
-<!---
-Chrystale75/Chrystale75 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Ce dépôt décrit les spécifications fonctionnelles pour l’application d’audit demandée :
+
+1. **Tableau de bord par critère/indicateur** avec états `OK` / `À compléter` / `Risque` et liens vers les preuves.
+2. **Pack d’audit exportable (PDF/ZIP)** incluant preuves, journal d’audit, procédures et bilans.
+3. **Checklist d’audit interne** avec assignation des tâches et dates limites.
+4. **Procédures opérationnelles** accessibles depuis l’application (gestion des réclamations, accessibilité, amélioration continue).
+
+## Documentation
+- [Tableau de bord](docs/dashboard.md)
+- [Pack d’audit exportable](docs/audit-pack.md)
+- [Checklist d’audit interne](docs/checklist.md)
+- [Procédures opérationnelles](docs/procedures.md)
+
+Chaque document précise les modèles de données, le parcours utilisateur et les règles métiers à implémenter.

--- a/docs/audit-pack.md
+++ b/docs/audit-pack.md
@@ -1,0 +1,36 @@
+# Pack d’audit exportable (PDF/ZIP)
+
+Spécifications pour générer un pack complet incluant les preuves, le journal d’audit, les procédures et les bilans.
+
+## Contenu minimum
+- **Résumé exécutif** : objectifs, périmètre, dates clés, équipe.
+- **Journal d’audit** : traçabilité des actions (création/validation de preuves, changements d’état des indicateurs).
+- **Preuves** : pièces jointes et liens exportés en structure arborescente par critère/indicateur.
+- **Procédures** : documents à jour (gestion des réclamations, accessibilité, amélioration continue).
+- **Bilans et constats** : synthèse des écarts, risques, actions correctives et dates cibles.
+
+## Format d’export
+- **ZIP** :
+  - `index.pdf` (ou `index.html` si rendu web avant conversion) comme porte d’entrée.
+  - Dossiers `preuves/<critere>/<indicateur>/` pour les pièces.
+  - Fichier `journal.csv` ou `journal.json` pour le log horodaté.
+  - Dossier `procedures/` pour les procédures officielles.
+- **PDF** :
+  - Généré à partir du rendu HTML du tableau de bord et des bilans.
+  - Table des matières, pagination, horodatage et signature numérique optionnelle.
+
+## Génération
+- Bouton « Exporter le pack d’audit » accessible depuis le tableau de bord.
+- Tâche asynchrone (file de messages) pour éviter les timeouts sur de gros volumes.
+- Statut d’export affiché dans l’UI avec lien de téléchargement à expiration contrôlée.
+
+## Sécurité et traçabilité
+- Accès restreint aux rôles « Auditeur » et « Administrateur ».
+- Chaque export enregistre : utilisateur, date, périmètre, statut, URL du paquet généré.
+- Hash des fichiers (SHA-256) dans un manifeste pour garantir l’intégrité.
+
+## Tests d’acceptation
+- Génération ZIP contenant au moins un critère avec indicateurs et preuves.
+- Journal d’audit exporté et lisible.
+- Procédures incluses et horodatage cohérent.
+- Téléchargement contrôlé par permissions.

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,0 +1,35 @@
+# Checklist d’audit interne
+
+Cette checklist structurée permet d’assigner des actions, suivre les échéances et tracer l’avancement.
+
+## Modèle de données
+| Champ                | Type            | Notes |
+|----------------------|-----------------|-------|
+| `id`                 | UUID            | Identifiant unique de la tâche |
+| `categorie`          | string          | Ex. Préparation, Conduite, Clôture |
+| `intitule`           | string          | Tâche à réaliser |
+| `description`        | text            | Détails et attentes |
+| `responsable`        | string          | Personne assignée |
+| `echeance`           | date            | Date limite |
+| `priorite`           | enum            | Basse / Normale / Haute |
+| `statut`             | enum            | `À faire`, `En cours`, `Bloqué`, `Fait` |
+| `preuves`            | array<string>   | URLs ou identifiants de preuves |
+| `commentaires`       | text            | Notes de suivi |
+| `dateMiseAJour`      | datetime        | Pour l’historique |
+
+## Workflow
+1. Création depuis le tableau de bord ou une vue dédiée « Audit interne ».
+2. Assignation obligatoire avec notification (email/Slack) et échéance.
+3. Suivi visuel : Kanban ou tableau filtrable par responsable, statut et échéance.
+4. Rappel automatique 48h avant l’échéance ; escalade si en retard.
+5. Chaque clôture de tâche doit référencer au moins une preuve ou un commentaire justifiant la validation.
+
+## Exemples de tâches
+- Préparation : définir le périmètre, collecter les politiques applicables, planifier les interviews.
+- Conduite : vérifier les journaux, tester les contrôles d’accès, valider les sauvegardes.
+- Clôture : rédiger le bilan, valider les actions correctives, archiver le pack d’audit.
+
+## Critères de succès
+- 100 % des tâches critiques atteintes avant la date d’audit.
+- Aucun élément marqué « Bloqué » plus de 3 jours sans commentaire.
+- Correspondance entre checklist et indicateurs du tableau de bord.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,52 @@
+# Tableau de bord par critère/indicateur
+
+Ce document définit la structure du tableau de bord permettant de suivre chaque critère et indicateur avec un état et des liens vers les preuves associées.
+
+## Structure des données
+- **Critère** : groupe d'indicateurs (ex. « Gouvernance », « Sécurité », « Accessibilité »).
+- **Indicateur** : élément mesurable rattaché à un critère.
+- **États possibles** :
+  - `OK` : conforme avec preuve validée.
+  - `À compléter` : informations ou preuves manquantes.
+  - `Risque` : non-conformité ou dérive identifiée.
+- **Preuve** : fichier, lien ou entrée de journal d'audit justifiant l'état.
+
+## Modèle technique recommandé
+| Champ                 | Type              | Notes |
+|-----------------------|-------------------|-------|
+| `id`                  | UUID              | Identifiant unique de l'indicateur |
+| `critere`             | string            | Clé du critère |
+| `intitule`            | string            | Nom de l'indicateur |
+| `description`         | text              | Rappel du besoin et du contrôle |
+| `etat`                | enum              | `OK`, `À compléter`, `Risque` |
+| `justification`       | text              | Commentaire court expliquant l'état |
+| `preuveUrls`          | array<string>     | Liens vers fichiers ou entrées du journal d'audit |
+| `responsable`         | string            | Personne en charge de l'indicateur |
+| `dateMiseAJour`       | datetime          | Horodatage de la dernière mise à jour |
+
+## Expérience utilisateur
+- Vue en tableau filtrable par critère, état, responsable et date de mise à jour.
+- Couleurs :
+  - Vert pour `OK`
+  - Orange pour `À compléter`
+  - Rouge pour `Risque`
+- Chaque ligne offre un bouton « Voir preuves » ouvrant la liste des pièces (fichiers, liens, références de journal d'audit).
+- Bouton « Ajouter/Mettre à jour » pour modifier l'état, la justification et rattacher des preuves.
+- Export CSV/Excel du tableau filtré pour partage rapide.
+
+## Règles métiers
+- Un indicateur marqué `OK` doit contenir au moins une preuve validée.
+- Un indicateur en `Risque` doit avoir une action corrective renseignée et une date cible.
+- Historiser les changements d'état dans le journal d'audit (utilisateur, date, ancien/nouvel état, commentaire).
+
+## Intégration avec les preuves
+- Les liens de preuves doivent pointer vers :
+  - Le pack d’audit exportable (PDF/ZIP) quand le fichier est déjà archivé.
+  - Les pièces jointes stockées (ex. S3, dossier partagé) avec contrôle d'accès.
+  - Les entrées du journal d'audit pour tracer les validations.
+
+## Indicateurs suggérés
+- Gouvernance : existence du responsable conformité, cycle de revue trimestriel.
+- Accessibilité : taux de pages conformes RGAA, rapport d’audit, plan d'action.
+- Sécurité : journalisation active, politique de mots de passe, sauvegardes testées.
+- Satisfaction : délai de traitement des réclamations, taux de résolution.

--- a/docs/procedures.md
+++ b/docs/procedures.md
@@ -1,0 +1,25 @@
+# Procédures opérationnelles
+
+Ces procédures doivent être accessibles depuis l’application (onglet « Documentation » ou lien contextuel dans le tableau de bord) et incluses dans le pack d’audit.
+
+## Gestion des réclamations
+1. **Collecte** : formulaire dédié ou canal support ; chaque réclamation reçoit un identifiant et une date d’ouverture.
+2. **Qualification** : évaluer la sévérité et l’impact, assigner un responsable.
+3. **Traitement** : analyser la cause, définir l’action corrective et l’échéance.
+4. **Communication** : informer le déclarant des étapes clés (accusé de réception, résolution, fermeture).
+5. **Clôture** : documenter la solution, associer les preuves (captures, échanges), mettre à jour les indicateurs du tableau de bord.
+6. **Capitalisation** : enregistrer les récurrences et intégrer les leçons dans l’amélioration continue.
+
+## Accessibilité
+1. **Référentiel** : appliquer le RGAA ou norme interne équivalente.
+2. **Évaluation** : audit régulier (automatisé + manuel) des pages clés.
+3. **Plan d’action** : prioriser les corrections par criticité (bloquant/majeur/mineur) et affecter les responsables.
+4. **Mise en conformité** : suivre l’avancement dans le tableau de bord ; exiger une preuve (rapport, capture) pour passer un indicateur en `OK`.
+5. **Publication** : mettre à jour la déclaration d’accessibilité et la page d’aide utilisateur.
+
+## Amélioration continue
+1. **Cycle PDCA** : Plan (identifier opportunités), Do (mettre en œuvre), Check (mesurer), Act (ajuster).
+2. **Revue périodique** : comité mensuel examinant les indicateurs en `Risque` et les actions correctives.
+3. **Suivi des actions** : les actions issues des bilans sont créées dans la checklist d’audit interne avec échéance et responsable.
+4. **Mesure** : définir des KPI (temps de résolution, nombre de réclamations récurrentes, taux de conformité accessibilité).
+5. **Documentation** : archiver comptes rendus, décisions et preuves dans le journal d’audit pour réutilisation lors des exports.


### PR DESCRIPTION
## Summary
- add documentation for the indicator dashboard with states and proof links
- define exportable audit pack requirements and internal audit checklist
- document operational procedures for complaints, accessibility, and continuous improvement

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939eb3ddeb88323841a599d9f21df3e)